### PR TITLE
Implementation: Basic quic-go in trxer

### DIFF
--- a/trxer.go
+++ b/trxer.go
@@ -7,7 +7,7 @@ import "net"
 import "time"
 import "strconv"
 import "sync"
-import "reflect"
+// import "reflect"
 
 // quic specific packages
 import "crypto/tls"
@@ -83,8 +83,7 @@ func quic_server(threads int) {
 	var accumulated uint64
 	port := PORT
 	connStats := make(chan measurement)
-	fmt.Println("Conn stats is of type: ", reflect.TypeOf(connStats))
-
+	
 	for i := 0; i < threads; i++ {
 		fmt.Println("Listening on port: ", port)
 		go quic_server_worker(connStats, port)
@@ -95,11 +94,9 @@ func quic_server(threads int) {
 		for i := 0; i < threads; i++ {
 		recvData := <- connStats
 		accumulated += recvData.bytes
-		fmt.Println("Received data: ", recvData, "on thread: ", i)
 		}
 
 		mByteSec := accumulated / (1000000 * uint64(UPDATE_INTERVAL))
-		fmt.Println("accumulated bytes: ", accumulated)
 		fmt.Println("Throughput MBytes/sec: ", mByteSec)
 		accumulated = 0
 	}

--- a/trxer.go
+++ b/trxer.go
@@ -89,7 +89,6 @@ func quic_server_worker(c chan<- measurement, port int) {
 	fmt.Println("goroutine: listening on ", listenAddr)
 	
 	tlsConf := create_tls_config()
-	// debug fmt.Println("goroutine: tls config is ", reflect.TypeOf(tlsConf))
 
 	/* Server started with ListenAddr
 	   Creates packet conn and listening on given address
@@ -100,7 +99,6 @@ func quic_server_worker(c chan<- measurement, port int) {
 	}
 
 	fmt.Println("goroutine: wait for incoming connection")
-	// debug fmt.Println("goroutine: packet conn is ", reflect.TypeOf(packetConn))
 	
 	// accept incoming connection
 	sess, err := packetConn.Accept()
@@ -109,7 +107,6 @@ func quic_server_worker(c chan<- measurement, port int) {
 	}
 
 	fmt.Println("goroutine: connection established")
-	// debug fmt.Println("goroutine: sess is ", reflect.TypeOf(sess))
 
 	// connection close
 	// possible candidates => different granularities
@@ -127,18 +124,10 @@ func quic_server_worker(c chan<- measurement, port int) {
 	}
 
 	fmt.Println("goroutine: stream accepted")
-	// debug fmt.Println("goroutine: stream id is ", reflect.TypeOf(stream))
 
 	start := time.Now()
 	
-	/*
-	fmt.Println("goroutine: UPDATE_INTERVAL is: ", reflect.TypeOf(UPDATE_INTERVAL))
-	fmt.Println("goroutine: buf is: ", reflect.TypeOf(buf))
-	fmt.Println("goroutine: bytesPerInterval is: ", reflect.TypeOf(bytesPerInterval))
-	*/
-
 	for {
-		// 1. stream read out
 		numBytes, err := io.ReadFull(stream, buf)
 		if err != nil {
 			panic("readStream")
@@ -148,14 +137,7 @@ func quic_server_worker(c chan<- measurement, port int) {
 		elapsed := time.Since(start)
 		// elapsed.Seconds() returns float64
 		if elapsed.Seconds() > float64(UPDATE_INTERVAL) {
-			// 2. make result
 			result := measurement{bytes: bytesPerInterval, time: elapsed.Seconds()}
-
-			/*
-			fmt.Println("goroutine: bytesPerInterval read: ", bytesPerInterval)
-			fmt.Println("goroutine: time elapsed: ", elapsed.Seconds())
-			*/
-
 			c <- result
 			bytesPerInterval = 0
 			start = time.Now()

--- a/trxer.go
+++ b/trxer.go
@@ -7,6 +7,7 @@ import "net"
 import "time"
 import "strconv"
 import "sync"
+//import "reflect"
 
 var UPDATE_INTERVAL = 5
 var PORT = 6666
@@ -18,12 +19,26 @@ type measurement struct {
 	time  float64
 }
 
-func quic_client_worker(addr string, wg sync.WaitGroup) {
-	fmt.Println("Dummy func for a client quic stream, i.e. single go routine")
+func quic_client_worker(addr string, wg *sync.WaitGroup) {
+	fmt.Println("Quic stream connecting to: ", addr)
+	defer wg.Done()
 }
 
 func quic_client(threads int, addr string) {
-	fmt.Println("Dummy func for client quic side")
+	startPort := PORT
+	var wg sync.WaitGroup
+
+	for i := 0;  i < threads; i++ {
+		destAddr := addr + ":" + strconv.Itoa(startPort)
+		startPort++
+
+		// increment sync primitive per thread
+		wg.Add(1)
+		go quic_client_worker(destAddr, &wg)
+	}
+
+	wg.Wait()
+	fmt.Println("Releasing threads")
 }
 
 func quic_server_worker(c chan<- measurement, port int) {

--- a/trxer.go
+++ b/trxer.go
@@ -21,10 +21,7 @@ import "io"
 
 var UPDATE_INTERVAL = 5
 var PORT = 6666
-
 var DEF_BUFFER_SIZE = 8096 * 8
-var MIN_BUFFER_SIZE = 4096
-var MAX_BUFFER_SIZE = 212992
 
 
 type measurement struct {
@@ -374,20 +371,14 @@ func main() {
 	protoPtr := flag.String("protocol", "udp", "quic, udp or tcp")
 	modePtr := flag.String("mode", "server", "server (\"localhost\") or IP address ")
 	threadPtr := flag.Int("threads", 1, "an int for numer of coroutines")
-	callSizePtr := flag.Int("call-size", DEF_BUFFER_SIZE, "quic application buffer in bytes")
+	callSizePtr := flag.Int("call-size", DEF_BUFFER_SIZE, "application buffer in bytes")
 
 	flag.Parse()
 	fmt.Println("trxer(c) - 2017")
 	fmt.Println("Protocol:", *protoPtr)
 	fmt.Println("Mode:", *modePtr)
 	fmt.Println("Threads:", *threadPtr)
-	fmt.Println("(Quic) Call Size: ", *callSizePtr)
-
-	if *callSizePtr < MIN_BUFFER_SIZE {
-		panic("Min buffer size violated")
-	} else if *callSizePtr > MAX_BUFFER_SIZE {
-		panic("Max buffer size violated")
-	}
+	fmt.Println("Call Size: ", *callSizePtr)
 
 	if *protoPtr == "udp" {
 		if *modePtr == "server" {

--- a/trxer.go
+++ b/trxer.go
@@ -19,7 +19,6 @@ import "math/big"
 import "encoding/pem"
 import "io"
 
-
 var UPDATE_INTERVAL = 5
 var PORT = 6666
 
@@ -38,7 +37,6 @@ func quic_client_worker(addr string, wg *sync.WaitGroup) {
 	/* create tls conf, true => TLS accepts any certificate presented
 	by the server and any host name in that certificate
 	 */
-	
 	tlsConf := tls.Config {InsecureSkipVerify: true}
 
 	session, err := quic.DialAddr(addr, &tlsConf, nil)
@@ -72,7 +70,6 @@ func quic_client(threads int, addr string) {
 		destAddr := addr + ":" + strconv.Itoa(port)
 		port++
 
-		// increment sync primitive per thread
 		wg.Add(1)
 		go quic_client_worker(destAddr, &wg)
 	}
@@ -90,9 +87,6 @@ func quic_server_worker(c chan<- measurement, port int) {
 	
 	tlsConf := create_tls_config()
 
-	/* Server started with ListenAddr
-	   Creates packet conn and listening on given address
-	 */
 	packetConn, err := quic.ListenAddr(listenAddr, tlsConf, nil)
 	if err != nil {
 		panic("listenAddr")
@@ -100,7 +94,6 @@ func quic_server_worker(c chan<- measurement, port int) {
 
 	fmt.Println("goroutine: wait for incoming connection")
 	
-	// accept incoming connection
 	sess, err := packetConn.Accept()
 	if err != nil {
 		panic("acceptConn")
@@ -108,16 +101,8 @@ func quic_server_worker(c chan<- measurement, port int) {
 
 	fmt.Println("goroutine: connection established")
 
-	// connection close
-	// possible candidates => different granularities
-	// 1) session.go: SESSION level => func (s *session) Close() err
-	// 2) server.go: CONNECTION level => func (s *Server) Close()
-	// 3) stream.go: STREAM level => func (s *stream) Close() err
 	defer sess.Close()
 
-	/* "return next stream opened by peer" => stream NOT streamID
-	   c.f. packet connection can consist of several bidirection streams
-	 */
 	stream, err := sess.AcceptStream ()
 	if err != nil {
 		panic("acceptStream")
@@ -132,10 +117,10 @@ func quic_server_worker(c chan<- measurement, port int) {
 		if err != nil {
 			panic("readStream")
 		}
+
 		bytesPerInterval += uint64(numBytes)
 
 		elapsed := time.Since(start)
-		// elapsed.Seconds() returns float64
 		if elapsed.Seconds() > float64(UPDATE_INTERVAL) {
 			result := measurement{bytes: bytesPerInterval, time: elapsed.Seconds()}
 			c <- result
@@ -195,7 +180,6 @@ func create_tls_config() *tls.Config {
 		fmt.Println("generateTlsCert")
 	}
 
-	// 7. return tls config struct, i dont get what struct member we're addressing...
 	return &tls.Config{Certificates: []tls.Certificate{tlsCert}}
 }
 

--- a/trxer.go
+++ b/trxer.go
@@ -25,11 +25,13 @@ type measurement struct {
 
 func quic_client_worker(addr string, wg *sync.WaitGroup) {
 	fmt.Println("Quic stream connecting to: ", addr)
+
 	buf := make([]byte, 1400, 1400)
 
 	/* create tls conf, true => TLS accepts any certificate presented
 	by the server and any host name in that certificate
 	 */
+	
 	tlsConf := tls.Config {InsecureSkipVerify: true}
 
 	session, err := quic.DialAddr(addr, &tlsConf, nil)
@@ -79,7 +81,7 @@ func quic_server(threads int) {
 	fmt.Println("Dummy func for server quic side")
 }
 
-func udp_client_worker(addr string, wg sync.WaitGroup) {
+func udp_client_worker(addr string, wg *sync.WaitGroup) {
 	defer wg.Done()
 	buf := make([]byte, 1400, 1400)
 	conn, err := net.Dial("udp", addr)
@@ -102,7 +104,7 @@ func udp_client(threads int, addr string) {
 	for i := 0; i < threads; i++ {
 		listen := addr + ":" + strconv.Itoa(port)
 		wg.Add(1)
-		go udp_client_worker(listen, wg)
+		go udp_client_worker(listen, &wg)
 		port += 1
 	}
 	wg.Wait()
@@ -168,7 +170,7 @@ func udp_server(threads int) {
 	}
 }
 
-func tcp_client_worker(addr string, wg sync.WaitGroup) {
+func tcp_client_worker(addr string, wg *sync.WaitGroup) {
 	defer wg.Done()
 	buf := make([]byte, BYTE_BUFFER_SIZE, BYTE_BUFFER_SIZE)
 	conn, err := net.Dial("tcp", addr)
@@ -191,7 +193,7 @@ func tcp_client(threads int, addr string) {
 	for i := 0; i < threads; i++ {
 		listen := addr + ":" + strconv.Itoa(port)
 		wg.Add(1)
-		go tcp_client_worker(listen, wg)
+		go tcp_client_worker(listen, &wg)
 		port += 1
 	}
 	wg.Wait()

--- a/trxer.go
+++ b/trxer.go
@@ -26,38 +26,30 @@ type measurement struct {
 func quic_client_worker(addr string, wg *sync.WaitGroup) {
 	fmt.Println("Quic stream connecting to: ", addr)
 	buf := make([]byte, 1400, 1400)
-	// debug fmt.Println("buf is: ", reflect.TypeOf(buf))
-
 
 	/* create tls conf, true => TLS accepts any certificate presented
 	by the server and any host name in that certificate
 	 */
 	tlsConf := tls.Config {InsecureSkipVerify: true}
 
-	// establishes connection to server
-	// note: blocks until server con up, if no counterpart => panic
 	session, err := quic.DialAddr(addr, &tlsConf, nil)
 	if err != nil {
 		panic("dialQuic")
 	}
-	// debug fmt.Println("session is: ", reflect.TypeOf(session))
 
 	// open bidirectional QUIC stream => can be used to open several streams?
 	stream, err := session.OpenStreamSync()
 	if err != nil {
 		panic("openStream")
 	}
-	// debug fmt.Println("stream is: ", reflect.TypeOf(stream))
 
 	for {
-		// write 1400 byte data from application layer
 		_, err := stream.Write(buf)
 		if err !=  nil {
 			panic("writeStream")
 		}
 	}
 
-	// check whether this is necessary:
 	defer session.Close()
 	defer wg.Done()
 }

--- a/trxer.go
+++ b/trxer.go
@@ -185,7 +185,7 @@ func create_tls_config() *tls.Config {
 
 func udp_client_worker(addr string, wg *sync.WaitGroup) {
 	defer wg.Done()
-	buf := make([]byte, 1400, 1400)
+	buf := make([]byte, BYTE_BUFFER_SIZE, BYTE_BUFFER_SIZE)
 	conn, err := net.Dial("udp", addr)
 	if err != nil {
 		panic("dial")

--- a/trxer.go
+++ b/trxer.go
@@ -127,36 +127,27 @@ func create_tls_config() *tls.Config {
 	if err != nil {
 		panic("generateRsa")
 	}
-
-	fmt.Println("goroutine called: pkey is type ", reflect.TypeOf(pKey))
-	//fmt.Println("goroutine called: pkey is ", pKey)
-
+	
 	// 2. x509 CERT template
 	certTemplate := x509.Certificate{SerialNumber: big.NewInt(1)}
-	fmt.Println("goroutine called: cert temp is type ", reflect.TypeOf(certTemplate))
 	
 	// 3. create self-signed x509 certificate => DER used for binary encoded certs
 	certDER, err := x509.CreateCertificate(rand.Reader, &certTemplate, &certTemplate, &pKey.PublicKey, pKey)
 	if err != nil {
 		panic("generateX509DER")
 	}
-	fmt.Println("goroutine called: cert DER is type ", reflect.TypeOf(certDER))
 
 	// 4. encode key in PEM
 	pKeyPEM := pem.EncodeToMemory(&pem.Block{Type : "RSA PRIVATE KEY", Bytes : x509.MarshalPKCS1PrivateKey(pKey)})
-	fmt.Println("goroutine called: pkeyPEM is type ", reflect.TypeOf(pKeyPEM))
 
 	// 5. encode certDER in PEM
 	certPEM := pem.EncodeToMemory(&pem.Block{Type : "CERTIFICATE", Bytes : certDER})
-	fmt.Println("goroutine called: certPEM is type ", reflect.TypeOf(certPEM))
 
 	// 6. create tls cert
 	tlsCert, err := tls.X509KeyPair(certPEM, pKeyPEM)
 	if err != nil {
 		fmt.Println("generateTlsCert")
 	}
-	fmt.Println("goroutine called: tlsCert is type ", reflect.TypeOf(tlsCert))
-	// fmt.Println("goroutine called: tlsCert is ", tlsCert)
 
 	// 7. return tls config struct, i dont get what struct member we're addressing...
 	return &tls.Config{Certificates: []tls.Certificate{tlsCert}}

--- a/trxer.go
+++ b/trxer.go
@@ -32,7 +32,7 @@ type measurement struct {
 func quic_client_worker(addr string, wg *sync.WaitGroup) {
 	fmt.Println("Quic stream connecting to: ", addr)
 
-	buf := make([]byte, 1400, 1400)
+	buf := make([]byte, BYTE_BUFFER_SIZE, BYTE_BUFFER_SIZE)
 
 	/* create tls conf, true => TLS accepts any certificate presented
 	by the server and any host name in that certificate
@@ -80,7 +80,7 @@ func quic_client(threads int, addr string) {
 
 func quic_server_worker(c chan<- measurement, port int) {
 	var bytesPerInterval uint64 = 0
-	buf := make([]byte, 1400, 1400)
+	buf := make([]byte, BYTE_BUFFER_SIZE, BYTE_BUFFER_SIZE)
 	listenAddr := "[::]:" + strconv.Itoa(port)
 
 	fmt.Println("goroutine: listening on ", listenAddr)

--- a/trxer.go
+++ b/trxer.go
@@ -18,6 +18,22 @@ type measurement struct {
 	time  float64
 }
 
+func quic_client_worker(addr string, wg sync.WaitGroup) {
+	fmt.Println("Dummy func for a client quic stream, i.e. single go routine")
+}
+
+func quic_client(threads int, addr string) {
+	fmt.Println("Dummy func for client quic side")
+}
+
+func quic_server_worker(c chan<- measurement, port int) {
+	fmt.Println("Dummy func for a server quic stream, i.e. single go routine")
+}
+
+func quic_server(threads int) {
+	fmt.Println("Dummy func for server quic side")
+}
+
 func udp_client_worker(addr string, wg sync.WaitGroup) {
 	defer wg.Done()
 	buf := make([]byte, 1400, 1400)
@@ -203,7 +219,7 @@ func tcp_server_worker(c chan<- measurement, port int) {
 }
 
 func main() {
-	protoPtr := flag.String("protocol", "udp", "udp or tcp")
+	protoPtr := flag.String("protocol", "udp", "quic, udp or tcp")
 	modePtr := flag.String("mode", "server", "server (\"localhost\") or IP address ")
 	threadPtr := flag.Int("threads", 1, "an int for numer of coroutines")
 
@@ -224,6 +240,14 @@ func main() {
 			tcp_server(*threadPtr)
 		} else {
 			tcp_client(*threadPtr, *modePtr)
+		}
+	} else if *protoPtr == "quic" {
+		if *modePtr == "server" {
+			// server
+			quic_server(*threadPtr)
+		} else {
+			// client
+			quic_client(*threadPtr, *modePtr)
 		}
 	} else {
 		panic("udp or tcp")

--- a/trxer.go
+++ b/trxer.go
@@ -9,6 +9,10 @@ import "strconv"
 import "sync"
 //import "reflect"
 
+// quic specific packages
+import "crypto/tls"
+import quic "github.com/lucas-clemente/quic-go"
+
 var UPDATE_INTERVAL = 5
 var PORT = 6666
 
@@ -21,6 +25,40 @@ type measurement struct {
 
 func quic_client_worker(addr string, wg *sync.WaitGroup) {
 	fmt.Println("Quic stream connecting to: ", addr)
+	buf := make([]byte, 1400, 1400)
+	// debug fmt.Println("buf is: ", reflect.TypeOf(buf))
+
+
+	/* create tls conf, true => TLS accepts any certificate presented
+	by the server and any host name in that certificate
+	 */
+	tlsConf := tls.Config {InsecureSkipVerify: true}
+
+	// establishes connection to server
+	// note: blocks until server con up, if no counterpart => panic
+	session, err := quic.DialAddr(addr, &tlsConf, nil)
+	if err != nil {
+		panic("dialQuic")
+	}
+	// debug fmt.Println("session is: ", reflect.TypeOf(session))
+
+	// open bidirectional QUIC stream => can be used to open several streams?
+	stream, err := session.OpenStreamSync()
+	if err != nil {
+		panic("openStream")
+	}
+	// debug fmt.Println("stream is: ", reflect.TypeOf(stream))
+
+	for {
+		// write 1400 byte data from application layer
+		_, err := stream.Write(buf)
+		if err !=  nil {
+			panic("writeStream")
+		}
+	}
+
+	// check whether this is necessary:
+	defer session.Close()
 	defer wg.Done()
 }
 


### PR DESCRIPTION
Extended trxer with the quic-go lib. We can do the following:
- Quic connection setup and teardown
- Create quic streams
- Send data between Server and Client
- Measure throughput   

What we cannot do:
- Match the linerate (bad with loopback, worse with direct ethernet connection) 
- The best performance is achieved loopback on the i7 with 8 x 3,4 GHZ (240 MByte/s) 
- When I benchmark with the direct connection the "bad" workstations might be a bottleneck. 
- see additional information in commit msg 
